### PR TITLE
enhancement: for prettier line ending in different os

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "lf",
   "singleQuote": true,
   "trailingComma": "all"
 }


### PR DESCRIPTION
fix the inconsistent line endings for different OS by enforcing to be Unix style line ending when prettier formatting the code 